### PR TITLE
Raise exception if request to log10.io API fails in load.py

### DIFF
--- a/log10/load.py
+++ b/log10/load.py
@@ -168,6 +168,11 @@ async def log_async(completion_url, func, **kwargs):
 
         if DEBUG:
             log_url(res, completionID)
+        
+        # in case the usage of load(openai) and langchain.ChatOpenAI
+        if "api_key" in kwargs:
+            kwargs.pop("api_key")
+
         log_row = {
             # do we want to also store args?
             "status": "started",
@@ -199,6 +204,9 @@ def log_sync(completion_url, func, **kwargs):
     completionID = res.json()["completionID"]
     if DEBUG:
         log_url(res, completionID)
+    # in case the usage of load(openai) and langchain.ChatOpenAI
+    if "api_key" in kwargs:
+        kwargs.pop("api_key")
     log_row = {
         # do we want to also store args?
         "status": "started",
@@ -267,6 +275,10 @@ def intercepting_decorator(func):
                             "index": 0,
                         }
                     ]
+
+                # in case the usage of load(openai) and langchain.ChatOpenAI
+                if "api_key" in kwargs:
+                    kwargs.pop("api_key")
 
                 log_row = {
                     "response": json.dumps(output),

--- a/log10/load.py
+++ b/log10/load.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 import logging
 from dotenv import load_dotenv
 import backoff  # for exponential backoff
-from openai import error
+from log10.openai import RETRY_ERROR_TYPES as OPENAI_RETRY_ERROR_TYPES
 
 load_dotenv()
 
@@ -34,16 +34,8 @@ if target_service == "bigquery":
 elif target_service is None:
     target_service = "log10"  # default to log10
 
-errors = (
-    error.APIConnectionError,
-    error.APIError,
-    error.RateLimitError,
-    error.ServiceUnavailableError,
-    error.Timeout,
-)
 
-
-@backoff.on_exception(backoff.expo, errors)
+@backoff.on_exception(backoff.expo, OPENAI_RETRY_ERROR_TYPES)
 def func_with_backoff(func, *args, **kwargs):
     return func(*args, **kwargs)
 

--- a/log10/load.py
+++ b/log10/load.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 import logging
 from dotenv import load_dotenv
 import backoff  # for exponential backoff
-from openai.error import RateLimitError, APIConnectionError
+from openai import error
 
 load_dotenv()
 
@@ -34,8 +34,16 @@ if target_service == "bigquery":
 elif target_service is None:
     target_service = "log10"  # default to log10
 
+errors = (
+    error.APIConnectionError,
+    error.APIError,
+    error.RateLimitError,
+    error.ServiceUnavailableError,
+    error.Timeout,
+)
 
-@backoff.on_exception(backoff.expo, (RateLimitError, APIConnectionError))
+
+@backoff.on_exception(backoff.expo, errors)
 def func_with_backoff(func, *args, **kwargs):
     return func(*args, **kwargs)
 

--- a/log10/openai.py
+++ b/log10/openai.py
@@ -12,7 +12,7 @@ from openai import error
 import openai
 
 
-errors = (
+RETRY_ERROR_TYPES = (
     error.APIConnectionError,
     error.APIError,
     error.RateLimitError,
@@ -25,7 +25,7 @@ class OpenAI(LLM):
     def __init__(self, hparams: dict = None, log10_config=None):
         super().__init__(hparams, log10_config)
 
-    @backoff.on_exception(backoff.expo, errors)
+    @backoff.on_exception(backoff.expo, RETRY_ERROR_TYPES)
     def chat(self, messages: List[Message], hparams: dict = None) -> ChatCompletion:
         request = self.chat_request(messages, hparams)
 
@@ -59,7 +59,7 @@ class OpenAI(LLM):
             **merged_hparams,
         }
 
-    @backoff.on_exception(backoff.expo, errors)
+    @backoff.on_exception(backoff.expo, RETRY_ERROR_TYPES)
     def text(self, prompt: str, hparams: dict = None) -> TextCompletion:
         request = self.text_request(prompt, hparams)
 

--- a/log10/openai.py
+++ b/log10/openai.py
@@ -8,15 +8,24 @@ import logging
 
 # for exponential backoff
 import backoff
-from openai.error import RateLimitError, APIConnectionError
+from openai import error
 import openai
+
+
+errors = (
+    error.APIConnectionError,
+    error.APIError,
+    error.RateLimitError,
+    error.ServiceUnavailableError,
+    error.Timeout,
+)
 
 
 class OpenAI(LLM):
     def __init__(self, hparams: dict = None, log10_config=None):
         super().__init__(hparams, log10_config)
 
-    @backoff.on_exception(backoff.expo, (RateLimitError, APIConnectionError))
+    @backoff.on_exception(backoff.expo, errors)
     def chat(self, messages: List[Message], hparams: dict = None) -> ChatCompletion:
         request = self.chat_request(messages, hparams)
 
@@ -50,7 +59,7 @@ class OpenAI(LLM):
             **merged_hparams,
         }
 
-    @backoff.on_exception(backoff.expo, (RateLimitError, APIConnectionError))
+    @backoff.on_exception(backoff.expo, errors)
     def text(self, prompt: str, hparams: dict = None) -> TextCompletion:
         request = self.text_request(prompt, hparams)
 


### PR DESCRIPTION
- propagate exception or errors happens with post request to log10.io API. 

- fixed log10-io/log10.io#1031 remove `api_key` if it exists in the request. It happens when using log10.load + langchain.ChatOpenAI

Next:
- [ ] add mock test for failed API calls log10-io/log10.io#1034