### PR TITLE
Widening the langchain versions supported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ build = "^0.10.0"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-langchain = "^0.0.303"
+langchain = "<0.2.0"
 openai = "<2"
 requests = "^2.31.0"
 python-dotenv = "^1.0.0"


### PR DESCRIPTION
Realized `^0.0.X` release ranges means `>=0.0.X, <0.0.X+1` (special case for "0.0." releases) (https://python-poetry.org/docs/dependency-specification/) so we had to change our dependency range to support both openai 0.X and 1.X releases with langchain