### PR TITLE
revert python requirements to 3.9+

### DIFF
--- a/log10/feedback/_summary_feedback_utils.py
+++ b/log10/feedback/_summary_feedback_utils.py
@@ -1,6 +1,16 @@
-from magentic import SystemMessage, UserMessage, chatprompt
-from magentic.chat_model.openai_chat_model import OpenaiChatModel
-from magentic.chatprompt import escape_braces
+import sys
+
+
+if sys.version_info < (3, 10):
+    raise RuntimeError("Python 3.10 or higher is required to run summary feedback llm call.")
+
+try:
+    from magentic import SystemMessage, UserMessage, chatprompt
+    from magentic.chat_model.openai_chat_model import OpenaiChatModel
+    from magentic.chatprompt import escape_braces
+except ImportError as error:
+    msg = "To use summary feedback llm call, you need to install magentic package. Please install it using 'pip install log10-io[autofeedback_icl]'"
+    raise ImportError(msg) from error
 
 
 # define prompts for tldr dataset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,14 @@ build = "^0.10.0"
 pytest = "^8.0.0"
 requests-mock = "^1.11.0"
 respx = "^0.20.2"
+ruff = "^0.3.2"
 
 [project.urls]
 "Homepage" = "https://github.com/log10-io/log10"
 "Bug Tracker" = "https://github.com/log10-io/log10/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<4.0"
+python = ">=3.9,<4.0"
 langchain = "<0.2.0"
 openai = "<2"
 requests = "^2.31.0"
@@ -48,8 +49,12 @@ backoff = "^2.2.1"
 anthropic = "<1"
 mosaicml-cli = "^0.5.30"
 together = "^0.2.7"
-magentic = "^0.17.0"
-google-cloud-aiplatform = "^1.44.0"
+google-cloud-aiplatform = ">=1.44.0"
+
+magentic = {version = ">=0.17.0", optional = true}
+
+[tool.poetry.extras]
+autofeedback_icl = ["magentic"]
 
 [tool.ruff]
 # Never enforce `E501` (line length violations).


### PR DESCRIPTION
revert python requirements to 3.9+
- update magentic to optional for autofeedback_icl feature only
- can do install with `pip install log10-io[autofeedback_icl]`