### PR TITLE
Introduces MockLLM and provides an example

### DIFF
--- a/examples/feedback/echo/echo.py
+++ b/examples/feedback/echo/echo.py
@@ -1,0 +1,39 @@
+import random
+from pydantic import BaseModel
+
+def ground_truth(n: str) -> str:
+    return str(n)
+
+def noisy_predictor(n: str) -> str:
+    n_int = int(n)
+    return str(n_int + random.randint(-10, 10)) if random.randint(1, 10) <= 5 else n
+
+def _echo_eval(ground_truth: str, prediction: str) -> int:
+    return int(ground_truth) - int(prediction)
+
+def _rating_emoji(diff: int) -> str:
+    if diff == 0:
+        return "✅"
+    elif diff > 0:
+        return f"↗️"
+    else:
+        return "↘"
+
+def _verbal_rating(diff: int) -> str:
+    ratings = [
+        (lambda d: d == 0, "perfect"),
+        (lambda d: 0 < d < 3, "good"),
+        (lambda d: 3 <= d < 6, "okay"),
+        (lambda d: 6 <= d < 8, "bad"),
+        (lambda d: d >= 8, "terrible"),
+    ]
+    return next(rating for condition, rating in ratings if condition(abs(diff)))
+
+class EchoFeedback(BaseModel):
+    direction: str
+    verbal_rating: str
+
+    @staticmethod
+    def create(ground_truth: str, prediction: str) -> "EchoFeedback":
+        diff = _echo_eval(ground_truth, prediction)
+        return EchoFeedback(direction=_rating_emoji(diff), verbal_rating=_verbal_rating(diff))

--- a/examples/feedback/echo/noisy_echo_feedback.py
+++ b/examples/feedback/echo/noisy_echo_feedback.py
@@ -1,0 +1,39 @@
+import random
+from dotenv import load_dotenv
+from random_word import RandomWords
+from echo import ground_truth, noisy_predictor, EchoFeedback
+from log10.llm import MockLLM, Message, Log10Config
+from log10.feedback.feedback import Feedback
+from log10.feedback.feedback_task import FeedbackTask
+
+
+load_dotenv()
+
+def mk_tag(prefix):
+    rw = RandomWords()
+    return f"{prefix}-{rw.get_random_word()}-{rw.get_random_word()}"
+
+
+if __name__ == "__main__":
+    # each time you run you have the same task name, but a different session name
+    task_name = "echo"
+    session_tag = mk_tag(task_name)
+    input_offset = random.randint(0, 100)
+    random_seed = 42
+    # set a random seed for the noisy predictor.
+    # This seed will be logged as a tag for reproducibility.
+    random.seed(random_seed)
+    config = Log10Config(tags=[session_tag, task_name, f"random_seed:{random_seed}"])
+    # we will mock the llm with a function
+    client = MockLLM(mock_function=noisy_predictor, log10_config=config)
+    task = FeedbackTask().create(name=task_name, 
+                                 task_schema=EchoFeedback.model_json_schema())
+    task_id = task.json()["id"]
+    for i in range(10):
+        x = i + input_offset
+        y = ground_truth(x)
+        response = client.chat([Message(role="user", content=str(x))])
+        y_hat = response.content
+        l10fb = EchoFeedback.create(y, y_hat)        
+        response = Feedback().create(task_id=task_id, values=l10fb.model_dump(), completion_tags_selector=config.tags)
+        print(f"{response.json()['id']}: {l10fb}")

--- a/log10/llm.py
+++ b/log10/llm.py
@@ -309,7 +309,7 @@ class MockLLM(LLM):
     def chat_expected(self, messages: List[Message], expected: Message, hparams: dict = None) -> ChatCompletion:
         '''
         Similar to chat, except it takes a list of messages and a single expected message.
-        It will return the expected message. 
+        It will return the expected message. If any `mock_function` is set previously, it will be ignored.
         '''
         tmp_mock_func = self.mock_function
         self.mock_function = lambda _: expected.content


### PR DESCRIPTION
**Rationale:** For testing and other purposes, we need a Log10 LLM instance that mimics an LLM chat call but doesn't rely on existing LLMs, local or otherwise. The NoopLLM class provides an interface that always produces a constant output. However, for testing feedback/logging, you might want to have a mock LLM that produces different but deterministic outputs for different inputs. This PR provides that.

As a choice, the current implementation only provides `.chat()` to facilitate my current work and leaves `.text()` for future implementation.