### PR TITLE
set feedback list task_id default to "" instead of None

### DIFF
--- a/log10/feedback/feedback.py
+++ b/log10/feedback/feedback.py
@@ -59,7 +59,7 @@ class Feedback:
         res = self._post_request(self.feedback_create_url, json_payload)
         return res
 
-    def list(self, offset: int = 0, limit: int = 50, task_id: str = None) -> httpx.Response:
+    def list(self, offset: int = 0, limit: int = 50, task_id: str = "") -> httpx.Response:
         base_url = self._log10_config.url
         api_url = "/api/v1/feedback"
         url = f"{base_url}{api_url}?organization_id={self._log10_config.org_id}&offset={offset}&limit={limit}&task_id={task_id}"


### PR DESCRIPTION
repro code:
```
from log10.feedback.feedback import Feedback

if __name__ == "__main__":
    fb = Feedback()
    fb.list()
```
Error due to incorrectly set `task_id=None` in request url and get 500 internal error.
