### PR TITLE
fix cli import issue when magentic is not installed

### DIFF
--- a/log10/feedback/autofeedback.py
+++ b/log10/feedback/autofeedback.py
@@ -8,10 +8,16 @@ import openai
 from rich.console import Console
 
 from log10.completions.completions import _get_completion
-from log10.feedback._summary_feedback_utils import flatten_messages, summary_feedback_llm_call
 from log10.feedback.feedback import _get_feedback_list
 from log10.load import log10, log10_session
 
+
+try:
+    from log10.feedback._summary_feedback_utils import flatten_messages, summary_feedback_llm_call
+
+    Magentic_imported = True
+except ImportError:
+    Magentic_imported = False
 
 log10(openai)
 
@@ -28,6 +34,10 @@ class AutoFeedbackICL:
     _predict_func: FunctionType = None
 
     def __init__(self, task_id: str, num_samples: int = 5, predict_func: FunctionType = summary_feedback_llm_call):
+        if not Magentic_imported:
+            raise ImportError(
+                "Log10 feedback predict requires magentic package. Please install using 'pip install log10-io[autofeedback_icl]'"
+            )
         self.num_samples = num_samples
         self.task_id = task_id
         self._predict_func = predict_func


### PR DESCRIPTION
Need to update `feedback/autofeedback.py` to check import as well. Otherwise, it breaks the whole cli. 
error:
```
log10 ❯ log10 --help
Traceback (most recent call last):
  File "/Users/wenzhe/dev/log10/log10/feedback/_summary_feedback_utils.py", line 8, in <module>
    from magentic import SystemMessage, UserMessage, chatprompt
ModuleNotFoundError: No module named 'magentic'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/wenzhe/dev/log10/.venv/bin/log10", line 5, in <module>
    from log10.__main__ import cli
  File "/Users/wenzhe/dev/log10/log10/__main__.py", line 4, in <module>
    from log10.feedback.autofeedback import auto_feedback_icl
  File "/Users/wenzhe/dev/log10/log10/feedback/autofeedback.py", line 11, in <module>
    from log10.feedback._summary_feedback_utils import flatten_messages, summary_feedback_llm_call
  File "/Users/wenzhe/dev/log10/log10/feedback/_summary_feedback_utils.py", line 13, in <module>
    raise ImportError(msg) from error
ImportError: To use summary feedback llm call, you need to install magentic package. Please install it using 'pip install log10-io[autofeedback_icl]'
```