### PR TITLE
use `asyncio.create_task` instead of `await` for log10 post calls

### DIFF
--- a/examples/logging/openai_async_stream_logging.py
+++ b/examples/logging/openai_async_stream_logging.py
@@ -3,6 +3,7 @@ import asyncio
 import openai
 from openai import AsyncOpenAI
 
+from log10._httpx_utils import gather_pending_async_tasks
 from log10.load import log10
 
 
@@ -14,11 +15,12 @@ client = AsyncOpenAI()
 async def main():
     stream = await client.chat.completions.create(
         model="gpt-4",
-        messages=[{"role": "user", "content": "Count to 50."}],
+        messages=[{"role": "user", "content": "Count to 20."}],
         stream=True,
     )
     async for chunk in stream:
         print(chunk.choices[0].delta.content or "", end="", flush=True)
+    await gather_pending_async_tasks()
 
 
 asyncio.run(main())

--- a/examples/logging/openai_async_stream_logging.py
+++ b/examples/logging/openai_async_stream_logging.py
@@ -3,7 +3,7 @@ import asyncio
 import openai
 from openai import AsyncOpenAI
 
-from log10._httpx_utils import gather_pending_async_tasks
+from log10._httpx_utils import finalize
 from log10.load import log10
 
 
@@ -20,7 +20,7 @@ async def main():
     )
     async for chunk in stream:
         print(chunk.choices[0].delta.content or "", end="", flush=True)
-    await gather_pending_async_tasks()
+    await finalize()
 
 
 asyncio.run(main())

--- a/log10/_httpx_utils.py
+++ b/log10/_httpx_utils.py
@@ -523,7 +523,7 @@ class _LogTransport(httpx.AsyncBaseTransport):
         return response
 
 
-async def gather_pending_async_tasks():
+async def finalize():
     pending = asyncio.all_tasks()
     pending.remove(asyncio.current_task())
     await asyncio.gather(*pending)


### PR DESCRIPTION
require to gather all pending tasks at the end
```
from log10._httpx_utils import finalize
...

await finalize()
```

- [ ] need to update the async examples with `finalize `, currently only change one example file