### PR TITLE
Filter out non completions

### DIFF
--- a/log10/_httpx_utils.py
+++ b/log10/_httpx_utils.py
@@ -4,6 +4,7 @@ import logging
 import time
 import traceback
 import uuid
+import httpcore
 from datetime import datetime, timezone
 
 import httpx
@@ -153,7 +154,10 @@ async def _try_post_request_async(url: str, payload: dict = {}) -> httpx.Respons
         else:
             logger.error(f"Failed with error: {http_err}")
     except Exception as err:
-        logger.error(f"Failed to insert in log10: {payload} with error {err}.", exc_info=True)
+        logger.error(
+            f"Failed to insert in log10 to {url}: {payload} with error {err}.",
+            exc_info=True,
+        )
 
 
 def format_anthropic_request(request_content) -> str:


### PR DESCRIPTION
We have had completion updates come in trying to use `/completions/None` - while we find out why it cannot find the completion id from the request (or if other non-log10 requests are using the same client somehow), filter out requests that cannot be completed