### PR TITLE
add cli auto-prompt analyze - prompt analyzer in cli

### DIFF
--- a/cli_docs.md
+++ b/cli_docs.md
@@ -200,6 +200,49 @@ To get auto generated feedback for a completion, use [`log10 feedback autofeedba
 
 ## CLI References
 
+```bash
+$ log10 --help
+Usage: log10 [OPTIONS] COMMAND [ARGS]...
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  auto-prompt    Analyze prompts and messages to get suggestions
+  completions    Manage logs from completions i.e.
+  feedback       Manage feedback for completions i.e.
+  feedback-task  Manage tasks for feedback i.e.
+```
+
+### Auto Prompt
+
+```bash
+$ log10 auto-prompt --help
+Usage: log10 auto-prompt [OPTIONS] COMMAND [ARGS]...
+
+  Analyze prompts and messages to get suggestions
+
+Options:
+  --help  Show this message and exit.
+
+Commands:
+  analyze Analyze a prompt or messages and provide suggestions on how to improve it. 
+```
+
+#### log10 auto-prompt analyze
+```bash
+$ log10 auto-prompt analyze --help
+Usage: log10 auto-prompt analyze [OPTIONS]
+
+  Analyze a prompt or messages and provide suggestions on how to improve it.
+
+Options:
+  -p, --prompt TEXT    The prompt to analyze. Provide a string or a file
+                       containing the prompt.
+  -m, --messages TEXT  The messages to analyze. Provide a JSON or JSON file of
+                       openai style messages.
+```
+
 ### Completions
 
 ```bash

--- a/cli_docs.md
+++ b/cli_docs.md
@@ -237,10 +237,16 @@ Usage: log10 auto-prompt analyze [OPTIONS]
   Analyze a prompt or messages and provide suggestions on how to improve it.
 
 Options:
-  -p, --prompt TEXT    The prompt to analyze. Provide a string or a file
-                       containing the prompt.
-  -m, --messages TEXT  The messages to analyze. Provide a JSON or JSON file of
-                       openai style messages.
+  -p, --prompt TEXT  The prompt to analyze. Provide a string or a file
+                     containing the prompt. We allow three formats: 1) string
+                     prompt, e.g. "Summarize this article in 3 sentences." 2)
+                     messages, e.g. [{"role": "user", "content": "Hello"},
+                     {"role": "assistant", "content": "Hi"}] 3) log10
+                     completion, e.g. {..., "request": {..., "messages":
+                     [{"role": "user", "content": "Hello"}, {"role":
+                     "assistant", "content": "Hi"}], ...}, "response": {...}}
+                     The prompt input could be a string or a file path. If
+                     it's a file path, read the file.
 ```
 
 ### Completions

--- a/log10/cli/autoprompt.py
+++ b/log10/cli/autoprompt.py
@@ -1,0 +1,52 @@
+import json
+from pathlib import Path
+
+import click
+
+from log10.prompt_analyzer import PromptAnalyzer, display_prompt_analyzer_suggestions
+
+
+@click.command()
+@click.option("--prompt", "-p", help="The prompt to analyze. Provide a string or a file containing the prompt.")
+@click.option(
+    "--messages", "-m", help="The messages to analyze. Provide a JSON or JSON file of openai style messages."
+)
+def autoprompt(prompt, messages):
+    """
+    Analyze a prompt or messages and provide suggestions on how to improve it.
+    """
+    if prompt and messages:
+        raise click.UsageError("You can only provide either a prompt or messages, not both.")
+    if not prompt and not messages:
+        click.echo("Enter the prompt to analyze (end with Ctrl+D):")
+        prompt = click.get_text_stream("stdin").read()
+        # prompt = click.prompt("Enter the prompt to analyze", type=str)
+
+    # prompt could be a string or a file path, if it's a file path, read the file load into a string
+    if prompt:
+        prompt_file = Path(prompt)
+        if prompt_file.exists():
+            with open(prompt_file, "r") as f:
+                prompt = f.read()
+                click.echo(f"Prompt loaded from {prompt_file}:")
+    elif messages:
+        messages_file = Path(messages)
+        if messages_file.exists():
+            # check message_file extension is json
+            if messages_file.suffix.lower() != ".json":
+                raise click.UsageError("Only .json extension is supported for the messages file.")
+            with open(messages_file, "r") as f:
+                # load messages_file to json, then extract the content of each message
+                messages = f.read()
+
+            try:
+                messages = json.loads(messages)
+            except json.JSONDecodeError:
+                raise click.UsageError("Invalid JSON format for messages file.")
+            click.echo(f"Messages loaded from {messages_file}:")
+        prompt = "\n\n".join([m.get("content", "") for m in messages])
+
+    click.echo(prompt)
+    analyzer = PromptAnalyzer()
+    suggestions = analyzer.analyze(prompt)
+    display_prompt_analyzer_suggestions(suggestions)

--- a/log10/cli/autoprompt.py
+++ b/log10/cli/autoprompt.py
@@ -6,45 +6,65 @@ import click
 from log10.prompt_analyzer import PromptAnalyzer, display_prompt_analyzer_suggestions
 
 
+# ignor "tool" and "funciton" roles
+ALLOWED_ROLES = {"system", "user", "assistant"}
+
+
 @click.command()
-@click.option("--prompt", "-p", help="The prompt to analyze. Provide a string or a file containing the prompt.")
 @click.option(
-    "--messages", "-m", help="The messages to analyze. Provide a JSON or JSON file of openai style messages."
+    "--prompt",
+    "-p",
+    help=(
+        "The prompt to analyze. Provide a string or a file containing the prompt. "
+        "We allow three formats:\n"
+        '1) string prompt, e.g. "Summarize this article in 3 sentences."\n'
+        '2) messages, e.g. [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi"}]\n'
+        '3) log10 completion, e.g. {..., "request": {..., "messages": [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi"}], ...}, "response": {...}}\n'
+    ),
 )
-def autoprompt(prompt, messages):
+def autoprompt(prompt):
     """
     Analyze a prompt or messages and provide suggestions on how to improve it.
     """
-    if prompt and messages:
-        raise click.UsageError("You can only provide either a prompt or messages, not both.")
-    if not prompt and not messages:
+    if not prompt:
         click.echo("Enter the prompt to analyze (end with Ctrl+D):")
         prompt = click.get_text_stream("stdin").read()
-        # prompt = click.prompt("Enter the prompt to analyze", type=str)
+        if not prompt:
+            raise click.BadParameter("No prompt provided.")
 
-    # prompt could be a string or a file path, if it's a file path, read the file load into a string
-    if prompt:
-        prompt_file = Path(prompt)
-        if prompt_file.exists():
-            with open(prompt_file, "r") as f:
-                prompt = f.read()
-                click.echo(f"Prompt loaded from {prompt_file}:")
-    elif messages:
-        messages_file = Path(messages)
-        if messages_file.exists():
-            # check message_file extension is json
-            if messages_file.suffix.lower() != ".json":
-                raise click.UsageError("Only .json extension is supported for the messages file.")
-            with open(messages_file, "r") as f:
-                # load messages_file to json, then extract the content of each message
-                messages = f.read()
+    # check if prompt is a file path
+    prompt_file = Path(prompt)
+    if prompt_file.exists():
+        with open(prompt_file, "r") as f:
+            click.echo(f"Prompt loaded from {prompt_file}:")
+            prompt = f.read()
 
-            try:
-                messages = json.loads(messages)
-            except json.JSONDecodeError:
-                raise click.UsageError("Invalid JSON format for messages file.")
-            click.echo(f"Messages loaded from {messages_file}:")
-        prompt = "\n\n".join([m.get("content", "") for m in messages])
+    # try to parse the prompt as a json
+    try:
+        prompt_json = json.loads(prompt)
+
+        if isinstance(prompt_json, list) and all("role" in item and "content" in item for item in prompt_json):
+            # prompt is a list of messages
+            prompt = "\n\n".join([f"{m["role"]}: {m["content"]}" for m in prompt_json if m["role"] in ALLOWED_ROLES])
+        elif isinstance(prompt_json, dict) and "request" in prompt_json and "messages" in prompt_json["request"]:
+            # prompt is a log10 completion
+            prompt = "\n\n".join(
+                [
+                    f"{m["role"]}: {m["content"]}"
+                    for m in prompt_json["request"]["messages"]
+                    if m["role"] in ALLOWED_ROLES
+                ]
+            )
+        elif isinstance(prompt_json, str):
+            # prompt is a plain string
+            prompt = prompt_json
+        else:
+            raise click.BadParameter(
+                "Unsupported JSON format. Please provide a list of messages or a log10 completion."
+            )
+    except json.JSONDecodeError:
+        # Input is a plain string
+        prompt = prompt
 
     click.echo(prompt)
     analyzer = PromptAnalyzer()

--- a/log10/cli/autoprompt.py
+++ b/log10/cli/autoprompt.py
@@ -45,12 +45,12 @@ def autoprompt(prompt):
 
         if isinstance(prompt_json, list) and all("role" in item and "content" in item for item in prompt_json):
             # prompt is a list of messages
-            prompt = "\n\n".join([f"{m["role"]}: {m["content"]}" for m in prompt_json if m["role"] in ALLOWED_ROLES])
+            prompt = "\n\n".join([f'{m["role"]}: {m["content"]}' for m in prompt_json if m["role"] in ALLOWED_ROLES])
         elif isinstance(prompt_json, dict) and "request" in prompt_json and "messages" in prompt_json["request"]:
             # prompt is a log10 completion
             prompt = "\n\n".join(
                 [
-                    f"{m["role"]}: {m["content"]}"
+                    f'{m["role"]}: {m["content"]}'
                     for m in prompt_json["request"]["messages"]
                     if m["role"] in ALLOWED_ROLES
                 ]

--- a/log10/cli/cli_commands.py
+++ b/log10/cli/cli_commands.py
@@ -10,6 +10,7 @@ except ImportError:
     exit(1)
 
 from log10.cli.autofeedback import auto_feedback_icl, get_autofeedback_cli
+from log10.cli.autoprompt import autoprompt
 from log10.cli.completions import benchmark_models, download_completions, get_completion, list_completions
 from log10.cli.feedback import create_feedback, download_feedback, get_feedback, list_feedback
 from log10.cli.feedback_task import create_feedback_task, get_feedback_task, list_feedback_task
@@ -52,6 +53,14 @@ def feedback_task():
     pass
 
 
+@click.group()
+def auto_prompt():
+    """
+    Analyze prompts and messages to get suggestions
+    """
+    pass
+
+
 cli.add_command(completions)
 completions.add_command(list_completions, "list")
 completions.add_command(get_completion, "get")
@@ -72,3 +81,6 @@ cli.add_command(feedback_task)
 feedback_task.add_command(create_feedback_task, "create")
 feedback_task.add_command(list_feedback_task, "list")
 feedback_task.add_command(get_feedback_task, "get")
+
+cli.add_command(auto_prompt)
+auto_prompt.add_command(autoprompt, "analyze")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,3 +92,8 @@ def test_list_feedback_task(runner):
 def test_get_feedback_task(runner):
     result = runner.invoke(cli, ["feedback-task", "get", "--id", feedback_task_id])
     assert result.exit_code == 0
+
+
+def test_auto_prompt(runner):
+    result = runner.invoke(cli, ["auto-prompt", "analyze", "--prompt", "Summarize this article in 3 sentences."])
+    assert result.exit_code == 0


### PR DESCRIPTION
Three input format allowed:

1. string prompt, e.g. "Summarize this article in 3 sentences." 
2. openai chat messages, e.g. `[{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Hi"}]`
3. log10 completion (can be downloaded via cli [log10 completions get](https://github.com/log10-io/log10/blob/main/cli_docs.md#log10-completions-get)), e.g. 
```
{..., "request": {..., "messages": [{"role": "user", "content": "Hello"}, {"role":
"assistant", "content": "Hi"}], ...}, "response": {...}}
```

Doc:
```
❯ log10 auto-prompt analyze --help
Usage: log10 auto-prompt analyze [OPTIONS]

  Analyze a prompt or messages and provide suggestions on how to improve it.

Options:
  -p, --prompt TEXT  The prompt to analyze. Provide a string or a file
                     containing the prompt. We allow three formats: 1) string
                     prompt, e.g. "Summarize this article in 3 sentences." 2)
                     messages, e.g. [{"role": "user", "content": "Hello"},
                     {"role": "assistant", "content": "Hi"}] 3) log10
                     completion, e.g. {..., "request": {..., "messages":
                     [{"role": "user", "content": "Hello"}, {"role":
                     "assistant", "content": "Hi"}], ...}, "response": {...}}
```

e.g. 
`log10 auto-prompt analyze -p "this is a test prompt for autoprompt cli"`
or pass a file
`log10 auto-prompt analyze -p test.prompt`