### PR TITLE
pytest log10 updates to include url to evaluation page

### DIFF
--- a/src/log10/pytest_log10_managed_evaluation/README.md
+++ b/src/log10/pytest_log10_managed_evaluation/README.md
@@ -2,6 +2,12 @@
 
 A pytest plugin for managing evaluation in Log10 platform.
 
+## Overview
+
+This plugin facilitates the evaluation of LLM applications using Log10.
+For detailed information on how to start evaluating your LLM applications,
+please refer to our [evaluation documentation](https://docs.log10.io/evaluation).
+
 ## Installation
 After [configuring the Log10 environment variables](https://docs.log10.io/observability/advanced/logging#configuration),
 ```bash

--- a/src/log10/pytest_log10_managed_evaluation/plugin.py
+++ b/src/log10/pytest_log10_managed_evaluation/plugin.py
@@ -275,7 +275,7 @@ class JSONReport(JSONReportBase):
         except OSError as e:
             self._terminal_summary = "could not save report: {}".format(e)
         else:
-            self._terminal_summary = "report saved to: {}".format(path)
+            self._terminal_summary = "Report saved to: {}".format(path)
 
         if self.log10_test_run is not None:
             upload_url = self.log10_test_run.get("reportUploadUrl")
@@ -351,12 +351,14 @@ class JSONReport(JSONReportBase):
 
         terminalreporter.write_sep("=", "Log10 Eval Report")
         if self.log10_test_run:
-            terminalreporter.write_line(
-                f"Log10 Eval is enabled.\nTest run: {self.log10_test_run.get('name')}-{self.log10_test_run.get('id')}"
-            )
+            test_run_name = self.log10_test_run.get("name")
+            test_run_id = self.log10_test_run.get("id")
+            terminalreporter.write_line(f"Log10 Eval is enabled.\nTest run: {test_run_name}-{test_run_id}")
 
             # todo (wenzhe) add url to managed eval page in log10 UI
-            terminalreporter.write_line("Log10 managed evaluation page: <url-placeholder>")
+            test_run_org_slug = self.log10_test_run.get("organization", {}).get("slug")
+            evaluations_page_url = f"https://log10.io/app/{test_run_org_slug}/evaluations?id={test_run_id}"
+            terminalreporter.write_line(f"Log10 Evaluation URL: {evaluations_page_url}")
         else:
             terminalreporter.write_line("Log10 Eval runs locally.")
         terminalreporter.write_line(self._terminal_summary)

--- a/src/log10/pytest_log10_managed_evaluation/utils.py
+++ b/src/log10/pytest_log10_managed_evaluation/utils.py
@@ -13,6 +13,9 @@ def create_log10_test_run(eval_name: str):
         name
         reportUploadUrl
         createdAt
+        organization {
+          slug
+        }
       }
     }
     """


### PR DESCRIPTION
* add link to docs.log10.io
* add url to log10 evaluations page
* update create test run function, returning the org slug

example output and note the `Log10 Evaluation URL:` at the end:
```
========================================= test session starts ==========================================
platform darwin -- Python 3.12.2, pytest-8.3.3, pluggy-1.5.0
rootdir: test_log10_eval
plugins: metadata-3.1.1, anyio-4.6.0, log10-io-0.14.0
collected 1 item

test_example.py F                                                                                [100%]

=============================================== FAILURES ===============================================
_____________________________________________ test_example _____________________________________________

    def test_example():
>       assert 0 == 1
E       assert 0 == 1

test_example.py:4: AssertionError
========================================== Log10 Eval Report ===========================================
Log10 Eval is enabled.
Test run: tests-06aedd36-69af-45bb-918a-b1cab4e79298
Log10 Evaluation URL: log10.io/app/test-org/evaluations?id=06aedd36-69af-45bb-918a-b1cab4e79298
Report saved to: test_log10_eval/.pytest_log10_eval_reports/tests-06aedd36-69af-45bb-918a-b1cab4e79298.report.json
Report successfully uploaded to Log10
======================================= short test summary info ========================================
FAILED test_example.py::test_example - assert 0 == 1
========================================== 1 failed in 27.13s ==========================================

```