### PR TITLE
replace pydantic copy with model_copy. copy is deprecated

### DIFF
--- a/src/log10/completions/completions.py
+++ b/src/log10/completions/completions.py
@@ -109,7 +109,7 @@ def _get_llm_repsone(
             model=model, messages=messages, temperature=temperature, max_tokens=max_tokens, top_p=top_p
         )
         ret["content"] = response.choices[0].message.content
-        ret["usage"] = response.usage.dict()
+        ret["usage"] = response.usage.model_dump()
     elif "claude-3" in model:
         from log10.load import Anthropic
 

--- a/src/log10/litellm.py
+++ b/src/log10/litellm.py
@@ -81,7 +81,7 @@ class Log10LitellmLogger(CustomLogger, LLM):
 
         completion_id = run["completion_id"]
         last_completion_response_var.set({"completionID": completion_id})
-        self.log_end(completion_id, response_obj.dict(), duration)
+        self.log_end(completion_id, response_obj.model_dump(), duration)
 
     def log_failure_event(self, kwargs, response_obj, start_time, end_time):
         update_log_row = {

--- a/src/log10/load.py
+++ b/src/log10/load.py
@@ -419,7 +419,7 @@ class StreamingResponseWrapper:
             elif tc := chunk.choices[0].delta.tool_calls:
                 # self.tool_calls is a list
                 if tc[0].id:
-                    self.tool_calls.append(tc[0].dict())
+                    self.tool_calls.append(tc[0].model_dump())
                 elif tc[0].function.arguments:
                     self.tool_calls[tc[0].index]["function"]["arguments"] += tc[0].function.arguments
             elif chunk.choices[0].finish_reason:
@@ -483,7 +483,7 @@ class StreamingResponseWrapper:
                     ],
                 }
             if self.usage:
-                response["usage"] = self.usage.dict()
+                response["usage"] = self.usage.model_dump()
             self.partial_log_row["response"] = json.dumps(response)
             self.partial_log_row["duration"] = int((time.perf_counter() - self.start_time) * 1000)
 

--- a/src/log10/load.py
+++ b/src/log10/load.py
@@ -799,7 +799,7 @@ def intercepting_decorator(func):
                     if type(output).__name__ == "LegacyAPIResponse":
                         response = json.loads(output.content)
                     else:
-                        response = output.copy()
+                        response = output.model_copy()
                         if "choices" in response:
                             response = flatten_response(response)
                 elif "lamini" in func.__module__:
@@ -832,7 +832,7 @@ def intercepting_decorator(func):
                             response=response,
                             partial_log_row=log_row,
                         )
-                    response = output.copy()
+                    response = output.model_copy()
 
                 if hasattr(response, "model_dump_json"):
                     response = response.model_dump_json()


### PR DESCRIPTION
The warning in the tests:
```
❯ pytest tests/test_openai.py::test_chat
============================================== test session starts ==============================================
platform darwin -- Python 3.12.2, pytest-8.2.0, pluggy-1.5.0
rootdir: /Users/wenzhe/dev/log10/tests
configfile: pytest.ini
plugins: respx-0.20.2, anyio-4.3.0, metadata-3.1.1, log10-io-0.14.1, asyncio-0.23.6, requests-mock-1.12.1
asyncio: mode=Mode.STRICT
collected 1 item

tests/test_openai.py .                                                                                    [100%]

=============================================== warnings summary ================================================
test_openai.py::test_chat
  /Users/wenzhe/dev/log10/venv/lib/python3.12/site-packages/pydantic/main.py:1265: PydanticDeprecatedSince20: The `copy` method is deprecated; use `model_copy` instead. See the docstring of `BaseModel.copy` for details about how to handle `include` and `exclude`. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.7/migration/
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================= 1 passed, 1 warning in 2.03s ==========================================
```

After fix, no warning:
```
❯ pytest tests/test_openai.py::test_chat
============================================== test session starts ==============================================
platform darwin -- Python 3.12.2, pytest-8.2.0, pluggy-1.5.0
rootdir: /Users/wenzhe/dev/log10/tests
configfile: pytest.ini
plugins: respx-0.20.2, anyio-4.3.0, metadata-3.1.1, log10-io-0.14.1, asyncio-0.23.6, requests-mock-1.12.1
asyncio: mode=Mode.STRICT
collected 1 item

tests/test_openai.py .                                                                                    [100%]

=============================================== 1 passed in 2.04s ===============================================
```